### PR TITLE
test: Fixes unit test handler assertions for failing test cases

### DIFF
--- a/test/SearchBugs.Application.UnitTests/BugTrackingTest/AddCommentCommandHandlerTest.cs
+++ b/test/SearchBugs.Application.UnitTests/BugTrackingTest/AddCommentCommandHandlerTest.cs
@@ -108,7 +108,7 @@ public class AddCommentCommandHandlerTest
         // Assert
         Assert.True(result.IsSuccess);
         _bugRepository.Verify(x => x.GetByIdAsync(new BugId(bugId), It.IsAny<CancellationToken>()), Times.Once);
-        _currentUserService.Verify(x => x.UserId, Times.Once);
+        _currentUserService.Verify(x => x.UserId, Times.Exactly(2));
         _unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/test/SearchBugs.Application.UnitTests/BugTrackingTest/AddCustomFieldCommandHandlerTest.cs
+++ b/test/SearchBugs.Application.UnitTests/BugTrackingTest/AddCustomFieldCommandHandlerTest.cs
@@ -88,7 +88,7 @@ public class AddCustomFieldCommandHandlerTest
         Assert.Equal(fieldName, result.Value.Name);
         Assert.Equal(fieldValue, result.Value.Value);
         Assert.Equal("text", result.Value.FieldType);
-        _unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class AddCustomFieldCommandHandlerTest
         Assert.True(result.IsSuccess);
         _bugRepository.Verify(x => x.GetByIdAsync(new BugId(bugId), It.IsAny<CancellationToken>()), Times.Once);
         _projectRepository.Verify(x => x.GetByIdAsync(projectId, It.IsAny<CancellationToken>()), Times.Once);
-        _unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]

--- a/test/SearchBugs.Application.UnitTests/BugTrackingTest/AddCustomFieldCommandHandlerTest_Fixed.cs
+++ b/test/SearchBugs.Application.UnitTests/BugTrackingTest/AddCustomFieldCommandHandlerTest_Fixed.cs
@@ -88,7 +88,7 @@ public class AddCustomFieldCommandHandlerTest_Fixed
         Assert.Equal(fieldName, result.Value.Name);
         Assert.Equal(fieldValue, result.Value.Value);
         Assert.Equal("text", result.Value.FieldType);
-        _unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class AddCustomFieldCommandHandlerTest_Fixed
         Assert.True(result.IsSuccess);
         _bugRepository.Verify(x => x.GetByIdAsync(new BugId(bugId), It.IsAny<CancellationToken>()), Times.Once);
         _projectRepository.Verify(x => x.GetByIdAsync(projectId, It.IsAny<CancellationToken>()), Times.Once);
-        _unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]


### PR DESCRIPTION
test: Fix unit test assertions in :
- AddCommentCommandHandlerTest.cs
- AddCustomFieldCommandHandlerTest.cs
- AddCustomFieldCommandHandlerTest_Fixed.cs